### PR TITLE
Various Fixes

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -4,4 +4,4 @@ license = Perl_5
 copyright_holder = Jerome Quelin
 copyright_year   = 2011
 
-[@JQUELIN]
+[@Author::JQUELIN]

--- a/lib/Dist/Zilla/App/Command/pot.pm
+++ b/lib/Dist/Zilla/App/Command/pot.pm
@@ -84,7 +84,7 @@ __END__
 
 =head1 SYNOPSIS
 
-    $ dzil pot -p lib/LocaleData/Foo-Bar-messages.pot
+    $ dzil pot -o lib/LocaleData/Foo-Bar-messages.pot
     $ dzil pot
 
 

--- a/lib/Dist/Zilla/App/Command/pot.pm
+++ b/lib/Dist/Zilla/App/Command/pot.pm
@@ -39,8 +39,9 @@ sub execute {
         grep { $_->name =~ /\.pm$/ }
         grep { $_->isa( "Dist::Zilla::File::OnDisk" ) }
         $zilla->files->flatten;
-    @pmfiles = grep { $_->_original_name ~~ @{ $opts->{input} } } @pmfiles
-        if $opts->{input};
+
+    @pmfiles = $self->_filter_input_files($opts->{input}, @pmfiles);
+
     my $tmp = File::Temp->new( UNLINK=>1 );
     $tmp->print( map { $_->name . "\n" } @pmfiles );
     $tmp->close;
@@ -77,6 +78,15 @@ sub execute {
         "-o", $opts->{output},
         "-f", $tmp
     ) == 0 or die "xgettext exited with return code " . ($? >> 8);
+}
+
+sub _filter_input_files {
+  my ($self, $input, @pmfiles) = @_;
+
+  return @pmfiles unless $input && @$input;
+
+  my %filter = map { ($_ => 1) } @$input;
+  return grep { $filter{ $_->_original_name } } @pmfiles;
 }
 
 1;

--- a/lib/Dist/Zilla/App/Command/pot.pm
+++ b/lib/Dist/Zilla/App/Command/pot.pm
@@ -22,7 +22,7 @@ sub opt_spec {
     return (
         [],
         [ "output|o=s", "location of the messages.pot to update" ],
-        [ "input|i=s@", "location of the messages.pot to update" ],
+        [ "input|i=s@", "input file(s) (defaults to all .pm files)" ],
     );
 }
 


### PR DESCRIPTION
I installed perl 5.20, and apparently has this module installed,
so when I ran `dzil` it spouted warnings about the experimental smartmatch operator being used.

I looked at the dist quick, a noticed a few issues.
I've never used this, and it's old, so I almost didn't submit the pull-req,
but then I figured since I spent a few minutes I would send it to you and let you decide.

Take what (if anything) you want from this.
